### PR TITLE
Add small installation hint for users who have added their Google account already

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ You want to have **License Verification and In-App-Purchases with microG** and a
 
 **Important:** Do NOT flash in TWRP, you need to use the Magisk app and have an active internet connection for downloading the patched PlayStore.
 
+**Note:** If you decide to install this module at a later stage and you have already added your Google account to microG, it may be necessary to remove your account from the system first and sign in again after the installation.
+
+
 ## NanoDroid or microG Installer Revived already do the job, don't they?
 
 Yes and no. After several tries with combinations of LineageOS 18.1, Lineage OS 18.1 for microG, NanoDroid and microG Installer Revived, I always ended up with either an unbootable system


### PR DESCRIPTION
I ran into a small issue when installing your module just now. The issue was fairly simple. I had added my Google account already some time ago before now installing this module. This caused the patched Playstore to always crash immediately. The solution is simple, just remove the Google account from the system and sign in again.

I thought it's worth to add a small hint in the Readme, so that other users don't need to figure this out themselves.

Thanks for this very convenient module 😁